### PR TITLE
Dev/model transitions param fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^\.github$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^data-raw$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Encoding: UTF-8
 LazyData: true
 Remotes:  
     mrc-ide/individual@0.0.8,
-    mrc-ide/squire@v0.5.4
+    mrc-ide/squire@v0.5.5
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Suggests:

--- a/R/model.R
+++ b/R/model.R
@@ -5,17 +5,24 @@
 #' dataframe with the number of individuals in each state at each timestep
 #'
 #' @param pop population. See [squire::get_population]
-#' @param parameters parameters list. 
+#' @param parameters parameters list.
 #'   See [squire::parameters_explicit_SEEIR]
 #' @export
 run_simulation <- function(pop, parameters) {
+
   parameters <- remove_non_numerics(parameters)
   states <- create_states(parameters)
-  human <- create_human(states)
+  variables <- create_variables(pop = pop)
+  events <- create_events()
+
+  human <- create_human(states = states, variables = variables, events = events)
+
+
   individual::simulate(
-    individuals = list(human),
+    individuals = human,
     processes = list(),
     end_timestep = parameters$time_period,
     parameters = parameters
   )
+
 }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -1,16 +1,24 @@
-#' @title Get parameters from SQUIRE model
+#' @title Get parameters from squire model
 #'
-#' @param pop population. See [squire::get_population]
-#' @param dt the timestep (days) for the simulation
-#' @param time_period the number timesteps to run the simulation for
+#' @inheritParams squire::parameters_explicit_SEEIR
 #' @param ... Other parameters for [squire::parameters_explicit_SEEIR]
 #'
-#' @return SQUIRE parameters
+#' @return squire model parameters
 #' @export
-get_parameters <- function(pop, dt = 1, time_period = 365, ...) {
+get_parameters <- function(country = NULL,
+                           population = NULL,
+                           contact_matrix_set = NULL,
+                           time_period = 365,
+                           ...) {
+
+  # dt should always be 1 as individual is always discrete time
+  dt <- 1
+
   c(
     squire::parameters_explicit_SEEIR(
-      population = pop$n,
+      population = population,
+      country = country,
+      contact_matrix_set = contact_matrix_set,
       dt = dt,
       time_period = time_period,
       ...
@@ -19,12 +27,12 @@ get_parameters <- function(pop, dt = 1, time_period = 365, ...) {
   )
 }
 
-#' @title Get population from SQUIRE model
+#' @title Get population from squire model
 #' @description rounds population sizes to discrete numbers
 #'
-#' @param countryname name of country
+#' @param country name of country
 #' @return population
 #' @export
-get_population <- function(countryname) {
-  squire::get_population(countryname, simple_SEIR = FALSE)
+get_population <- function(country) {
+  squire::get_population(country = country, simple_SEIR = FALSE)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 [![codecov.io](https://codecov.io/github/mrc-ide/hypatia/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/hypatia?branch=main)
 <!-- badges: end -->
 
-The goal of hypatia is to enable SQUIRE to be run on an individual basis rather than aggregate
+The goal of hypatia is to enable squire to be run on an individual basis rather than aggregate
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ status](https://github.com/mrc-ide/hypatia/workflows/R-CMD-check/badge.svg)](htt
 [![codecov.io](https://codecov.io/github/mrc-ide/hypatia/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/hypatia?branch=main)
 <!-- badges: end -->
 
-The goal of hypatia is to enable SQUIRE to be run on an individual basis
+The goal of hypatia is to enable squire to be run on an individual basis
 rather than aggregate
 
 ## Installation

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -2,22 +2,35 @@
 % Please edit documentation in R/parameters.R
 \name{get_parameters}
 \alias{get_parameters}
-\title{Get parameters from SQUIRE model}
+\title{Get parameters from squire model}
 \usage{
-get_parameters(pop, dt = 1, time_period = 365, ...)
+get_parameters(
+  country = NULL,
+  population = NULL,
+  contact_matrix_set = NULL,
+  time_period = 365,
+  ...
+)
 }
 \arguments{
-\item{pop}{population. See \link[squire:get_population]{squire::get_population}}
+\item{country}{Character for country beign simulated. WIll be used to
+generate \code{population} and \code{contact_matrix_set} if
+unprovided. Either \code{country} or \code{population} and
+\code{contact_matrix_set} must be provided.}
 
-\item{dt}{the timestep (days) for the simulation}
+\item{population}{Population vector (for each age group). Default = NULL,
+which will cause population to be sourced from \code{country}}
 
-\item{time_period}{the number timesteps to run the simulation for}
+\item{contact_matrix_set}{Contact matrices used in simulation. Default =
+NULL, which will generate this based on the \code{country}.}
+
+\item{time_period}{Length of simulation. Default = 365}
 
 \item{...}{Other parameters for \link[squire:parameters_explicit_SEEIR]{squire::parameters_explicit_SEEIR}}
 }
 \value{
-SQUIRE parameters
+squire model parameters
 }
 \description{
-Get parameters from SQUIRE model
+Get parameters from squire model
 }

--- a/man/get_population.Rd
+++ b/man/get_population.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/parameters.R
 \name{get_population}
 \alias{get_population}
-\title{Get population from SQUIRE model}
+\title{Get population from squire model}
 \usage{
-get_population(countryname)
+get_population(country)
 }
 \arguments{
-\item{countryname}{name of country}
+\item{country}{name of country}
 }
 \value{
 population

--- a/tests/testthat/test-events.R
+++ b/tests/testthat/test-events.R
@@ -1,9 +1,8 @@
 test_that("create_event_based_processes assigns a listener to each event", {
 
-  pop <- get_population("Antigua and Barbuda")
-  contact_matrix_set = squire::get_mixing_matrix(iso3c = "ATG")
-  parameters <- get_parameters(pop, 1, 100, contact_matrix_set)
-
+  country <- "Antigua and Barbuda"
+  parameters <- get_parameters(country = country)
+  pop <- get_population(country = country)
   events <- create_events()
   states <- create_states(parameters)
   max_age <- 100

--- a/tests/testthat/test-model-integration.R
+++ b/tests/testthat/test-model-integration.R
@@ -1,13 +1,17 @@
 test_that("run_simulation can parameterise and run an Afghan model for 10 days", {
   expected_columns <- c('timestep')
-  pop <- get_population("Afghanistan")
+  country <- "Afghanistan"
+  pop <- get_population(country = country)
+  pop$n <- as.integer(pop$n/100) # scale this for quick test
+
   parameters <- get_parameters(
-    pop,
+    population = pop$n, # scale this for quick test
     R0 = 2,
     time_period = 10,
     tt_contact_matrix = 0,
     contact_matrix_set = squire::contact_matrices[[1]]
   )
+
   output <- run_simulation(
     pop,
     parameters

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -10,11 +10,11 @@ test_that("test get_parameters returns the correct values from SQUIRE", {
   pop <- get_population("Afghanistan")
 
   psq <- get_parameters(
-    pop,
+    population = pop$n,
+    contact_matrix_set = contact_matrix_set,
     R0 = R0,
     time_period = time_period,
-    tt_contact_matrix = tt_contact_matrix,
-    contact_matrix_set = contact_matrix_set
+    tt_contact_matrix = tt_contact_matrix
   )
 
   expect_equal(psq$dt, 1)

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -1,6 +1,8 @@
 test_that("create_variables returns the correct output", {
 
   pop <- get_population("Afghanistan")
+  pop$n <- as.integer(pop$n/1000)
+
   theages <- create_variables(pop, 90)
   expect_length(length(theages$age), 1)
   expect_length(length(theages$discrete_age), 1)
@@ -11,6 +13,8 @@ test_that("create_variables returns the correct output", {
 test_that("create_continuous_age_variable creates the right number of ages", {
 
   pop <- get_population("Afghanistan")
+  pop$n <- as.integer(pop$n/1000)
+
   age <- create_continuous_age_variable(pop, max_age = 100)
   ages <- create_continuous_age_variable(pop)
   expect_length(ages, sum(pop$n))
@@ -20,6 +24,7 @@ test_that("create_continuous_age_variable creates the right number of ages", {
 test_that("test create_continuous_age_variable", {
 
   pop <- squire::get_population(iso3c = "ATG", simple_SEIR = FALSE)
+  pop$n <- as.integer(pop$n/1000)
 
   age_cont <- create_continuous_age_variable(pop)
 
@@ -30,6 +35,8 @@ test_that("test create_continuous_age_variable", {
 test_that("test create_discrete_age_variable", {
 
   pop <- squire::get_population(iso3c = "ATG", simple_SEIR = FALSE)
+  pop$n <- as.integer(pop$n/1000)
+
   ages <- create_continuous_age_variable(pop = pop, max_age = 100)
   disc_ages <- create_discrete_age_variable(ages, pop)
 


### PR DESCRIPTION
Hi Carol, 

I noticed that the `squire::parameters_explicit_SEEIR` is now being wrapped by the `get_parameters` function. This is fine, however, it was being used not quite right and have fixed. While doing that I noticed a few other fixes that were needed so I have wrapped them into this PR to bring into model transition. When this is merged I think we should be good to merge the `model_transitions` branch in to master. 

N.B:

1. Try and keen tests quick to run. For example, reducing the size of population used when testing the age functions:

```  
pop <- squire::get_population(iso3c = "ATG", simple_SEIR = FALSE)
pop$n <- as.integer(pop$n/1000)
```

